### PR TITLE
caddy: make caddy role arch-sensible

### DIFF
--- a/caddy/defaults/main.yml
+++ b/caddy/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+arch: amd64
 caddy_version: 2.7.6
 caddy_home_dir: /var/www
 caddy_file: Caddyfile

--- a/caddy/tasks/main.yml
+++ b/caddy/tasks/main.yml
@@ -53,7 +53,7 @@
   shell: |
     set -e
     cd `mktemp -d`
-    curl -fsSL -o caddy.tar.gz 'https://github.com/caddyserver/caddy/releases/download/v{{caddy_version}}/caddy_{{caddy_version}}_linux_amd64.tar.gz'
+    curl -fsSL -o caddy.tar.gz 'https://github.com/caddyserver/caddy/releases/download/v{{caddy_version}}/caddy_{{caddy_version}}_linux_{{arch}}.tar.gz'
     tar -xf caddy.tar.gz
     install -m 0755 caddy /usr/local/bin/caddy
     setcap 'cap_net_bind_service=+ep' /usr/local/bin/caddy


### PR DESCRIPTION
allow other architectures than amd64 to be used for the caddy binary while amd64 is still the default.