### PR TITLE
caddy: set default version to 2.8.4

### DIFF
--- a/caddy/defaults/main.yml
+++ b/caddy/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 arch: amd64
-caddy_version: 2.7.6
+caddy_version: 2.8.4
 caddy_home_dir: /var/www
 caddy_file: Caddyfile


### PR DESCRIPTION
Caddy was updated some time ago and seems to be stable in 2.8.4, I think we could update.